### PR TITLE
chore: switch to non deprecated URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <repository>
       <id>camunda public</id>
       <name>camunda</name>
-      <url>https://app.camunda.com/nexus/content/groups/public/</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
related to a change that was announced a while ago https://camunda.com/blog/2022/03/a-new-domain-name-for-camunda-artifactory/